### PR TITLE
Bump pandoc version to 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ env:
 
 before_install:
   # Fetch pandoc and pandoc-citeproc binaries
-  - wget https://github.com/jgm/pandoc/releases/download/1.15.0.5/pandoc-1.15.0.5-1-amd64.deb && ar p pandoc-1.15.0.5-1-amd64.deb data.tar.gz | tar zx
+  - wget https://github.com/jgm/pandoc/releases/download/2.1.1/pandoc-2.1.1-1-amd64.deb && ar p pandoc-2.1.1-1-amd64.deb data.tar.xz | tar xJ
   # Install TeX Live
-  - sudo add-apt-repository -y ppa:texlive-backports/ppa
   - sudo apt-get update -qq
-  - sudo apt-get install texlive-xetex texlive-latex-recommended texlive-latex-extra
-  - sudo apt-get install texlive-fonts-recommended texlive-fonts-extra
-  - sudo apt-get install texlive-science
+  - sudo apt-get install texlive-xetex texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra  texlive-science
   # Install fonts
   - sudo apt-get install lmodern
 
 # Attempt to create a PDF
 script:
   - make pdf
+  - make tex
+  - make docx
+  - make html

--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,18 @@ help:
 	@echo 'get templates from: https://github.com/jgm/pandoc-templates			  '
 
 pdf:
-	pandoc -s \
+	pandoc -s -f markdown-auto_identifiers \
 	"$(INPUTDIR)"/*.md \
 	-o "$(OUTPUTDIR)/cv.pdf" \
 	--template="$(STYLEDIR)/template.tex" \
-	--latex-engine=xelatex
+	--pdf-engine=xelatex
 
 tex:
 	pandoc -s \
 	"$(INPUTDIR)"/*.md \
 	-o "$(OUTPUTDIR)/cv.tex" \
 	--template="$(STYLEDIR)/template.tex" \
-	--latex-engine=xelatex
+	--pdf-engine=xelatex
 
 docx:
 	pandoc "$(INPUTDIR)"/*.md \


### PR DESCRIPTION
Hey, 
I bumped pandoc to the latest release. Using the current release produces a few errors, so a couple of changes were required in the Makefile, and TravisCI run trusty now so there's no need for the backports ppa.

Cheers!
