### PR TITLE
Added tlmgr self-update to Dockerfile...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM pandoc/alpine-latex:latest
 LABEL Name=markdowncv Version=0.0.1
 
+RUN tlmgr update --self
+
 RUN tlmgr install \ 
     enumitem \
     sectsty \


### PR DESCRIPTION
... because running the following Dockerfile command fails otherwise:

```
> [2/2] RUN tlmgr install     enumitem     sectsty     titling:                
#5 11.01 ===============================================================================                                                                        
#5 11.01 tlmgr itself needs to be updated.                                      
#5 11.01 Please do this via either                                              
#5 11.01   tlmgr update --self
#5 11.01 or by getting the latest updater for Unix-ish systems:
#5 11.01   https://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh
#5 11.02 and/or Windows systems:
#5 11.02   https://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.exe
#5 11.02 Then continue with other updates as usual.
#5 11.02 ===============================================================================
#5 11.02 tlmgr: Terminating; please see warning above!
#5 11.03 tlmgr: package repository https://mirrors.concertpass.com/tex-archive/systems/texlive/tlnet (verified)
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c tlmgr install     enumitem     sectsty     titling]: exit code: 255
```