### PR TITLE
Replace deprecated docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/alpine-latex:latest
+FROM pandoc/latex:latest
 LABEL Name=markdowncv Version=0.0.1
 
 RUN tlmgr install \ 

--- a/source/style/template.tex
+++ b/source/style/template.tex
@@ -23,7 +23,7 @@
 
 % FONTS
 \usepackage{xunicode}
-\usepackage{xltxtra}
+\usepackage{fontspec}
 \defaultfontfeatures{Mapping=tex-text} % converts LaTeX specials (quotes'' --- dashes etc.) to unicode
 % \setromanfont[Ligatures={Common}, Numbers={OldStyle}]{Palatino}
 % \setmonofont[Scale=1.0]{Monaco} 


### PR DESCRIPTION
Fix to close #10 

This just replaces the alpine image with new replacement. 
Changed xltxtra who features now has been incorporated into the [fontspec](https://ctan.org/pkg/fontspec)
https://ctan.org/pkg/xltxtra